### PR TITLE
add new proxy for redirect retrieval

### DIFF
--- a/WordpressRedirects/function.json
+++ b/WordpressRedirects/function.json
@@ -1,0 +1,19 @@
+{
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ]
+}

--- a/WordpressRedirects/index.js
+++ b/WordpressRedirects/index.js
@@ -1,0 +1,25 @@
+const fetch = require("node-fetch");
+
+module.exports = async function (context, req) {
+  try {
+    const redirectEndpoint =
+      "https://cannabis.ca.gov/wp-json/redirection/v1/export-public/1/json";
+
+    let output = await fetch(redirectEndpoint, {}).then((response) =>
+      response.json()
+    );
+    delete output.plugin.date; // purpose of this proxy is to remove this hourly updating date field
+
+    context.res = {
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(output),
+    };
+  } catch (error) {
+    console.log(error);
+    context.res = {
+      body: error
+    };
+  }
+};


### PR DESCRIPTION
This new proxy is a temporary solution to strip the date field from the redirect endpoint body.

This will prevent the publishing service from writing that file to github hourly as the date changes even though there are not content updates. Preventing this stops constant builds and AWS CloudFront cache clears from occurring unnecessarily